### PR TITLE
added support for different notation formats

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,32 +1,9 @@
 /**
  * @param {String} str
- * @return {Boolean}
- */
-function hasDecimalPart (str) {
-  str = filterNumbersDotsAndCommas(str)
-
-  return (
-    str[str.length - 3] === '.' ||
-    str[str.length - 3] === ','
-  )
-}
-
-/**
- * @param {String} str
- * @return {String}
- */
-function getDecimalSymbol (str) {
-  str = filterNumbersDotsAndCommas(str)
-  return str[str.length - 3]
-}
-
-/**
- * @param {String} str
  * @return {String}
  */
 function filterNumbers (str) {
-  var filteredStr = str.replace(/[^\d]/g, '')
-  return filteredStr
+  return str.replace(/[^\d]/g, '')
 }
 
 /**
@@ -37,27 +14,46 @@ function filterNumbersDotsAndCommas (str) {
   return str.replace(/[^\d.,]/g, '')
 }
 
+function getDecimalSymbol (str) {
+
+  var str_filtered = filterNumbersDotsAndCommas(str)
+  var endWithZero = str_filtered[str_filtered.length - 1] === '0'
+
+    // for each character starting from the end...
+  for (var i = str_filtered.length; i > 0; i--) {
+
+      // if the last character is a "0" and the decimal position > 3, no decimal
+    if (((str_filtered.length - i + 1) > 3) && endWithZero)
+      return
+
+    var currentChar = str_filtered[i - 1]
+
+    if ([',', '.'].indexOf(currentChar) !== -1)
+      return currentChar
+  }
+}
+
 //
 // API
 //
 
 /**
- * @param {String} str
+ * @param {Number|String} input
  * @return {Number}
  */
-function parsePrice (str) {
+function parsePrice (input) {
+
+  var str = String(input)
+
   var decimalPart = '00'
+  var decimalSymbol = getDecimalSymbol(str)
 
-  if (hasDecimalPart(str)) {
-    var decimalSymbol = getDecimalSymbol(str)
-    // There should be only one decimal symbol.
+  if (decimalSymbol)
     decimalPart = str.split(decimalSymbol)[1]
-    decimalPart = filterNumbers(decimalPart)
-  }
 
-  var integerPart = filterNumbers(str.split(decimalSymbol)[0])
+  var integerPart = str.split(decimalSymbol)[0]
 
-  return Number(integerPart + '.' + decimalPart)
+  return Number(filterNumbers(integerPart) + '.' + filterNumbers(decimalPart))
 }
 
 module.exports = parsePrice

--- a/src/index.js
+++ b/src/index.js
@@ -15,21 +15,21 @@ function filterNumbersDotsAndCommas (str) {
 }
 
 function getDecimalSymbol (str) {
-
-  var str_filtered = filterNumbersDotsAndCommas(str)
-  var endWithZero = str_filtered[str_filtered.length - 1] === '0'
+  var strFiltered = filterNumbersDotsAndCommas(str)
+  var endWithZero = strFiltered[strFiltered.length - 1] === '0'
 
     // for each character starting from the end...
-  for (var i = str_filtered.length; i > 0; i--) {
-
+  for (var i = strFiltered.length; i > 0; i--) {
       // if the last character is a "0" and the decimal position > 3, no decimal
-    if (((str_filtered.length - i + 1) > 3) && endWithZero)
+    if (((strFiltered.length - i + 1) > 3) && endWithZero) {
       return
+    }
 
-    var currentChar = str_filtered[i - 1]
+    var currentChar = strFiltered[i - 1]
 
-    if ([',', '.'].indexOf(currentChar) !== -1)
+    if ([',', '.'].indexOf(currentChar) !== -1) {
       return currentChar
+    }
   }
 }
 
@@ -42,14 +42,14 @@ function getDecimalSymbol (str) {
  * @return {Number}
  */
 function parsePrice (input) {
-
   var str = String(input)
 
   var decimalPart = '00'
   var decimalSymbol = getDecimalSymbol(str)
 
-  if (decimalSymbol)
+  if (decimalSymbol) {
     decimalPart = str.split(decimalSymbol)[1]
+  }
 
   var integerPart = str.split(decimalSymbol)[0]
 

--- a/test/prices-examples.js
+++ b/test/prices-examples.js
@@ -35,11 +35,6 @@ var prices = [
     input: '1,590 ₪',
     expectedOutput: 1590,
     name: 'ILS without cents'
-  },
-  {
-    input: '1,590.89 ₪',
-    expectedOutput: 1590.89,
-    name: 'ILS with cents'
   }
 ]
 
@@ -113,6 +108,42 @@ prices = prices.concat([
     input: '1.234,56 €',
     expectedOutput: 1234.56,
     name: 'EUR Spain'
+  }
+])
+
+// -------------------------------------------------------------------
+// Various input formats
+// -------------------------------------------------------------------
+prices = prices.concat([
+  {
+    input: 123.45,
+    expectedOutput: 123.45,
+    name: 'input cast to string'
+  },
+  {
+    input: '12.3',
+    expectedOutput: 12.3,
+    name: 'single digit at end with "."'
+  },
+  {
+    input: '12,3',
+    expectedOutput: 12.3,
+    name: 'single digit at end with ","'
+  },
+  {
+    input: '€12,3',
+    expectedOutput: 12.3,
+    name: 'single digit at end with "€"'
+  },
+  {
+    input: '12,3 €',
+    expectedOutput: 12.3,
+    name: 'single digit at end with "€" at end'
+  },
+  {
+    input: '$0.0005',
+    expectedOutput: 0.0005,
+    name: 'Higher precision floatig point'
   }
 ])
 


### PR DESCRIPTION
Fixed a bug with single precision decimals.

Added support for:
 - numbers as input instead of strings only
 - higher precision floats like 

```
"€5.0005" > 5.0005
```